### PR TITLE
Add a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+/target
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,18 +32,18 @@ RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
     adduser -D -u ${RUN_USER_UID} -G ${RUN_USER} ${RUN_USER}
 
 # Create the data directories and create a volume for them
+VOLUME /data
 RUN mkdir -p /data/state /datarsync /data/rrdp && \
-    chown -R ${RUNUSER_UID}:${RUN_USER_GID} /data
+    chown -R ${RUN_USER_UID}:${RUN_USER_GID} /data
 
 # Install a Docker entrypoint script that will be executed when the container
 # runs
 COPY docker/entrypoint.sh /opt/
-RUN chown ${RUN_USER}: /opt/entrypoint.sh
+RUN chown ${RUN_USER_UID}:${RUN_USER_GID} /opt/entrypoint.sh
 
 # Set default, non-existend rrdp url
 ENV RRDP_URL="https://localhost/notification.xml"
 
-VOLUME /data
 WORKDIR /tmp
 
 # Use Tini to ensure that krill-sync responds to CTRL-C when run in the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-#
-# Make the base image configurable so that the E2E test can use a base image
-# with a prepopulated Cargo build cache to accelerate the build process.
-# Use Ubuntu 16.04 because this is what the Travis CI Krill build uses.
+# Use the same alpine image for both build stages
 ARG BASE_IMG=alpine:3.13
 
 #
-# -- stage 1: build krill and krillc
+# -- stage 1: build krill-sync
 #
 FROM ${BASE_IMG} AS build
 
@@ -25,7 +22,7 @@ FROM ${BASE_IMG}
 COPY --from=build /tmp/krill_sync/target/x86_64-alpine-linux-musl/release/krill-sync /usr/local/bin/
 
 # Build variables for uid and guid of user to run container
-ARG RUN_USER=krill
+ARG RUN_USER=krill_sync
 ARG RUN_USER_UID=1012
 ARG RUN_USER_GID=1012
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ If new data is available the RRDP deltas will be used to update the local RRDP s
 
 The Notification File is always written to disk last.
 
+### Usage with docker
+
+The following environment variables exist:
+  * `FORMAT`: `Rsync|RRDP|Both`, defaults to `Both`
+  * `DATA`: path for data, defaults to `/data`
+  * `RRDP_DIR`: path for RRDP data, defaults to `${DATA}/rrdp`
+  * `RSYNC_DIR`: path for rsync data, defaults to `${DATA}/rsync`
+  * `STATE_DIR`: path for state, defaults to `${DATA}/state`
+
+```
+# Build the image and tag it
+docker build . -t krill-sync
+# Create data directory
+mkdir /tmp/data && sudo chown 1012 /tmp/data
+# Run one-shot
+docker run -v /tmp/data:/data --rm \
+    -e RRDP_URL="https://rrdp.rpki.nlnetlabs.nl/rrdp/notification.xml" \
+    krill-sync
+```
+
 ## Advanced Usage
 
 If needed the directories in which internal state and repository output are stored can be specified, and for servers that serve only RRDP or Rsync but not both it the output can be constrained to just the required format _(though the protocol used between krill-sync and the upstream RRDP server is always RRDP)_.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# run krill-sync with variable interpolation
+set -e
+FORMAT="${FORMAT:Both}"
+DATA="${DATA:-/data}"
+RRDP_DIR="${RRDP_DIR:-$DATA/rrdp}"
+RSYNC_DIR="${RSYNC_DIR:-$DATA/rsync}"
+STATE_DIR="${STATE_DIR:-$DATA/state}"
+
+exec /usr/local/bin/krill-sync \
+    -v \
+    --rrdp-dir ${RRDP_DIR} \
+    --rsync-dir ${RSYNC_DIR} \
+    --state-dir ${STATE_DIR} \
+    --format ${FORMAT} \
+    --pid-file ${DATA}/krill-sync.pid \
+    ${RRDP_URL}


### PR DESCRIPTION
  * Creates a docker container, based off the routinator/krill dockerfiles.
  * Uses an entrypoint because variable substitution does not work in `CMD` syntax.