### PR TITLE
Write full rsync paths when requested

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,10 @@ pub struct Opt {
     #[structopt(long = "force-update")]
     pub force_update: bool,
 
+    /// Include authority and module in rsync path (<rsync_dir>/rpki.example.org/respository/..)
+    #[structopt(long = "full-rsync-path")]
+    pub full_rsync_path: bool,
+
     /// Output both RRDP and Rsync style repositories or only one of them?
     #[structopt(long = "format", short = "f", default_value, possible_values(&Format::variants()), case_insensitive = true )]
     pub format: Format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ fn try_main() -> Result<()> {
                 &mut notify,
                 &rrdp_http_client,
                 &raw_snapshot,
-                state.notify_serial,
+                new_state.notify_serial,
             )?;
 
             let seconds_since_epoch = Utc::now().timestamp();

--- a/src/rsync.rs
+++ b/src/rsync.rs
@@ -42,7 +42,10 @@ pub fn build_repo_from_rrdp_snapshot(
     write_rsync_content(&out_path, notify, client, raw_snapshot)?;
 
     if cfg!(unix) {
-        info!("Use symlink to link rsync module dir to the new content");
+        info!(
+            "Using symlink to link rsync module dir to the new content in {}",
+            out_path.to_string_lossy()
+        );
         // create a new symlink then rename it
         let tmp_name = file_ops::set_path_ext(&opt.rsync_dir, config::TMP_FILE_EXT);
         std::os::unix::fs::symlink(&out_path, &tmp_name)?;


### PR DESCRIPTION
Should solve part of #18.

Open questions:
  * How to handle path injection - does the routinator code handle this?
  * How do we handle a transition between a run with `--full-rsync-path` and without