### PR TITLE
Write to rsync directory named after current serial

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ fn try_main() -> Result<()> {
                 &mut notify,
                 &rrdp_http_client,
                 &raw_snapshot,
-                state.notify_serial,
+                new_state.notify_serial,
             )?;
 
             let seconds_since_epoch = Utc::now().timestamp();

--- a/src/rsync.rs
+++ b/src/rsync.rs
@@ -42,7 +42,10 @@ pub fn build_repo_from_rrdp_snapshot(
     write_rsync_content(&out_path, notify, client, raw_snapshot)?;
 
     if cfg!(unix) {
-        info!("Use symlink to link rsync module dir to the new content");
+        info!(
+            "Using symlink to link rsync module dir to the new content in {}",
+            out_path.to_string_lossy()
+        );
         // create a new symlink then rename it
         let tmp_name = file_ops::set_path_ext(&opt.rsync_dir, config::TMP_FILE_EXT);
         std::os::unix::fs::symlink(&out_path, &tmp_name)?;


### PR DESCRIPTION
The rsync directory used the serial from the state, resulting in a directory named after serial-1 (or 0 on initial start). This resulted in krill-sync removing the current active rsync directory (which the symlink points to) if the previous run was the initial run or `serial-1` had expired.