### PR TITLE
Fix rsync symlink target for relative path

### DIFF
--- a/src/rsync.rs
+++ b/src/rsync.rs
@@ -45,7 +45,12 @@ pub fn build_repo_from_rrdp_snapshot(
         info!("Use symlink to link rsync module dir to the new content");
         // create a new symlink then rename it
         let tmp_name = file_ops::set_path_ext(&opt.rsync_dir, config::TMP_FILE_EXT);
-        std::os::unix::fs::symlink(&out_path, &tmp_name)?;
+        let target = if out_path.is_relative() {
+            out_path.file_name().map(|out_name| Path::new(".").join(out_name)).unwrap_or(out_path)
+        } else {
+            out_path
+        };
+        std::os::unix::fs::symlink(&target, &tmp_name)?;
         std::fs::rename(&tmp_name, &opt.rsync_dir)?;
     } else {
         info!("Renaming rsync folders for close to atomic update of the rsync module dir");


### PR DESCRIPTION
When a relative path for the rsync directory, fix the target of the symlink so it points to the correct output directory.