### PR TITLE
Fix rsync cleanup to handle RRDP session/serial resets

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -200,7 +200,6 @@ pub fn cleanup_notification_files(
 pub fn cleanup_rsync_dirs(
     path_to_cleanup: &Path,
     cleanup_older_than_ts: SecondsSinceEpoch,
-    last_serial: RrdpSerialNumber,
     publication_timestamps: &mut PublicationTimestamps) -> Result<()>
 {
     debug!("Remove old rsync directory backups published before {}",
@@ -213,8 +212,6 @@ pub fn cleanup_rsync_dirs(
             let num_cleaned = WalkDir::new(&parent).max_depth(1).into_iter()
                 .filter_map(|e| is_rsync_backup_dir(&e.unwrap(), path_to_cleanup))
                     .inspect(|(path, serial)| trace!("Found rsync backup dir for serial {}: {:?}", serial, path))
-                .filter(|(_, serial)| is_old_serial(*serial, last_serial))
-                    .inspect(|(_, serial)| trace!("Serial {} is old", serial))
                 .filter(|(_, serial)| is_expired_serial(*serial, &pub_ts_copy, cleanup_older_than_ts))
                     .inspect(|(_, serial)| debug!("Rsync backup for serial {} is expired and will be deleted", serial))
                 .fold(0, |acc, (path, serial)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,6 @@ fn try_main() -> Result<()> {
     cleanup::cleanup_rsync_dirs(
         &opt.rsync_dir,
         cleanup_older_than_ts,
-        state.notify_serial,
         &mut new_state.rsync_publication_timestamps,
     )?;
 


### PR DESCRIPTION
When a new RRDP session starts, the serial number resets. Since the expiration
of a serial was based on having any _higher_ serial that was not expired, any
snapshots in a new session are wiped until they catch up with the old session's
serial. This causes the rsync symlink to point to a non-existing directory,
breaking the repository.

With this patch the serial numbers are only used to track publication timestamps
in state. A serial can only expire when there is a _newer_ publication in
state. I.e. regardless of the age of the latest publication, it will never
expire.

Also allow for higher (yet older) serials to expire based on their publication time.