### PR TITLE
Use alternative xml writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.11.1-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=limit-notification-deltas#7aedb1651aa60484500f4bfb347582ee393dc185"
+source = "git+https://github.com/NLnetLabs/rpki-rs.git?branch=write-rrdp-xml#98588206558f7fde4b0017ef96443fe6da6b7749"
 dependencies = [
  "base64 0.13.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.18"
 fern = "0.6.0"
 log = "0.4.11"
 reqwest = { version = "0.11.3", features = [ "blocking"] }
-rpki = { version = "0.11.1-dev", features = [ "rrdp", "serde" ], git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "limit-notification-deltas" }
+rpki = { version = "0.11.1-dev", features = [ "rrdp", "serde" ], git = "https://github.com/NLnetLabs/rpki-rs.git", branch = "write-rrdp-xml" }
 serde = { version = "1.0.116", features =  ["derive"] } 
 serde_json = "1.0.57"
 structopt = { version = "0.3.18", default-features = false }

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -427,8 +427,7 @@ impl RrdpState {
         let notification = self.make_notification_file()?;
 
         let mut bytes: Vec<u8> = vec![];
-        let mut writer = rpki::xml::encode::Writer::new_with_indent(&mut bytes);
-        notification.to_xml(&mut writer)?;
+        notification.write_xml(&mut bytes)?;
 
         file_ops::write_buf(&tmp_path, &bytes)
             .with_context(|| "Could not write temporary notification file")?;
@@ -709,8 +708,7 @@ pub struct SnapshotState {
 impl SnapshotState {
     fn create(snapshot: &Snapshot) -> Self {
         let mut bytes: Vec<u8> = vec![];
-        let mut writer = rpki::xml::encode::Writer::new_with_indent(&mut bytes);
-        snapshot.to_xml(&mut writer).unwrap(); // cannot fail
+        snapshot.write_xml(&mut bytes).unwrap(); // cannot fail
         let xml: Bytes = bytes.into();
 
         let since = Time::now();
@@ -757,8 +755,7 @@ impl DeltaState {
         let serial = delta.serial();
 
         let mut bytes: Vec<u8> = vec![];
-        let mut writer = rpki::xml::encode::Writer::new_with_indent(&mut bytes);
-        delta.to_xml(&mut writer).unwrap(); // cannot fail
+        delta.write_xml(&mut bytes).unwrap(); // cannot fail
         let xml: Bytes = bytes.into();
 
         let hash = rrdp::Hash::from_data(xml.as_ref());


### PR DESCRIPTION
Will just merge this, as this code does not change the behaviour of krill-sync itself, but updates it to use the new rpki-rs code.