### PR TITLE
Add Ubuntu 22.04 packaging support.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -57,6 +57,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11
@@ -218,6 +219,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ assets = [
 
 [package.metadata.deb.variants.ubuntu-focal]
 
+[package.metadata.deb.variants.ubuntu-jammy]
+
 [package.metadata.deb.variants.debian-stretch]
 
 [package.metadata.deb.variants.debian-buster]


### PR DESCRIPTION
Add support for packaging for Ubuntu 22.04 Jammy Jellyfish, due for release on April 21, 2022.