### PR TITLE
Follow move of reusable pkg workflow to new ploutos repo.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -17,7 +17,7 @@ jobs:
     #
     # Set @vN to the latest released version.
     #
-    uses: NLnetLabs/.github/.github/workflows/pkg-rust.yml@v1
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v1
     with:
       #
       # Define the desired build stages. Each xxx_rules(_path) setting is optional but at least one should be set.


### PR DESCRIPTION
Rather than pollute the org wide central repo with the reusable packaging workflow, it has been moved to its own home in a new ploutos repo. This change follows that move.