### PR TITLE
Upgrade Ploutos

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -32,4 +32,3 @@ jobs:
       # Optional settings:
       #
       deb_extra_build_packages: libssl-dev
-      deb_maintainer: The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -24,8 +24,8 @@ jobs:
       # See https://github.com/NLnetLabs/.github/tree/main/workflow-templates/pkg for templates for each of the files referenced
       # below.
       #
-      package_build_rules_path: pkg/rules/packages-to-build.yml
-      package_test_rules_path: pkg/rules/packages-to-test.yml
+      package_build_rules: pkg/rules/packages-to-build.yml
+      package_test_rules: pkg/rules/packages-to-test.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh
 
       #

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -17,7 +17,7 @@ jobs:
     #
     # Set @vN to the latest released version.
     #
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v1
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
     with:
       #
       # Define the desired build stages. Each xxx_rules(_path) setting is optional but at least one should be set.


### PR DESCRIPTION
The current version v1 is hitting a problem that is solved in Ploutos v6. As this is quite a big upgrade this is a draft PR to investigate what if anything needs to be changed to make this repo work with newer Ploutos.