### PR TITLE
Build Docker image using Ploutos

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -17,7 +17,7 @@ jobs:
     # See: https://github.com/NLnetLabs/ploutos
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
     with:
-      cross_build_args: --features static-openssl
+      cross_build_args: --features static-tls
       cross_max_wait_mins: 20
 
       docker_org: nlnetlabs

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -16,6 +16,9 @@ jobs:
   package:
     # See: https://github.com/NLnetLabs/ploutos
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    secrets:
+      DOCKER_HUB_ID: ${{ vars.DOCKER_HUB_ID }}
+      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
     with:
       cross_build_args: --features static-tls
       cross_max_wait_mins: 20

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -24,6 +24,11 @@ jobs:
       # See https://github.com/NLnetLabs/.github/tree/main/workflow-templates/pkg for templates for each of the files referenced
       # below.
       #
+      docker_org: nlnetlabs
+      docker_repo: krill-sync
+      docker_build_rules: pkg/rules/docker-images-to-build.yml
+      docker_sanity_check_command: krill-sync --version
+
       package_build_rules: pkg/rules/packages-to-build.yml
       package_test_rules: pkg/rules/packages-to-test.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,16 +14,12 @@ on:
 
 jobs:
   package:
-    #
-    # Set @vN to the latest released version.
-    #
+    # See: https://github.com/NLnetLabs/ploutos
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
     with:
-      #
-      # Define the desired build stages. Each xxx_rules(_path) setting is optional but at least one should be set.
-      # See https://github.com/NLnetLabs/.github/tree/main/workflow-templates/pkg for templates for each of the files referenced
-      # below.
-      #
+      cross_build_args: --features static-openssl
+      cross_max_wait_mins: 20
+
       docker_org: nlnetlabs
       docker_repo: krill-sync
       docker_build_rules: pkg/rules/docker-images-to-build.yml
@@ -33,7 +29,4 @@ jobs:
       package_test_rules: pkg/rules/packages-to-test.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh
 
-      #
-      # Optional settings:
-      #
       deb_extra_build_packages: libssl-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +674,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ fern = "0.6.0"
 filetime = "0.2"
 fslock = "0.1.6"
 log = "0.4.11"
-reqwest = { version = "0.11.6", features = [ "native-tls", "blocking"] }
+reqwest = { version = "0.11.6", features = [ "blocking"] }
 rpki = { version = "0.15.8", features = [ "repository", "rrdp", "serde-support" ] }
 serde = { version = "1.0.116", features =  ["derive"] } 
 serde_json = "1.0.57"
@@ -31,7 +31,8 @@ rustc_version = "0.2.3"
 vergen = "3.1.0"
 
 [features]
-static-openssl = [ "openssl/vendored" ]
+default = ["reqwest/native-tls"]
+static-tls = [ "reqwest/native-tls-vendored" ]
 
 # ------------------------------------------------------------------------------
 # START DEBIAN PACKAGING

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ uuid = { version = "1.2.2", default-features = false }
 rustc_version = "0.2.3"
 vergen = "3.1.0"
 
+[features]
+static-openssl = [ "openssl/vendored" ]
 
 # ------------------------------------------------------------------------------
 # START DEBIAN PACKAGING

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,175 @@
-# Use the same alpine image for both build stages
+# This is a multi-stage Dockerfile, with a selectable first stage. With this
+# approach we get:
+#
+#   1. Separation of dependencies needed to build our app in the 'build' stage
+#      and those needed to run our app in the 'final' stage, as we don't want
+#      the build-time dependencies to be included in the final Docker image.
+#
+#   2. Support for either building our app for the architecture of the base
+#      image using MODE=build (the default) or for externally built app
+#      binaries (e.g. cross-compiled) using MODE=copy.
+#
+# In total there are four stages consisting of:
+#   - Two possible first stages: 'build' or 'copy'.
+#   - A special 'source' stage which selects either 'build' or 'copy' as the
+#     source of binaries to be used by ...
+#   - The 'final' stage.
+
+
+###
+### ARG DEFINITIONS ###########################################################
+###
+
+# This section defines arguments that can be overriden on the command line
+# when invoking `docker build` using the argument form:
+#
+#   `--build-arg <ARGNAME>=<ARGVALUE>`.
+
+# MODE
+# ====
+# Supported values: build (default), copy
+#
+# By default this Dockerfile will build our app from sources. If the sources
+# have already been (cross) compiled by some external process and you wish to
+# use the resulting binaries from that process, then:
+#
+#   1. Create a directory on the host called 'dockerbin/$TARGETPLATFORM'
+#      containing the already compiled app binaries (where $TARGETPLATFORM
+#      is a special variable set by Docker BuiltKit).
+#   2. Supply arguments `--build-arg MODE=copy` to `docker build`.
+ARG MODE=build
+
+
+# BASE_IMG
+# ========
+#
+# Only used when MODE=build.
 ARG BASE_IMG=alpine:3.18
 
+
+# CARGO_ARGS
+# ==========
 #
-# -- stage 1: build krill-sync
+# Only used when MODE=build.
 #
+# This ARG can be used to control the features enabled when compiling the app
+# or other compilation settings as necessary.
+ARG CARGO_ARGS
+
+
+###
+### BUILD STAGES ##############################################################
+###
+
+
+# -----------------------------------------------------------------------------
+# Docker stage: build
+# -----------------------------------------------------------------------------
+#
+# Builds our app binaries from sources.
 FROM ${BASE_IMG} AS build
+ARG CARGO_ARGS
 
-RUN apk add rust cargo openssl-dev
+RUN apk add --no-cache rust cargo openssl-dev
 
-WORKDIR /tmp/krill_sync
+WORKDIR /tmp/build
 COPY . .
 
-RUN cargo build --target x86_64-alpine-linux-musl --release --locked
+# `CARGO_HTTP_MULTIPLEXING` forces Cargo to use HTTP/1.1 without pipelining
+# instead of HTTP/2 with multiplexing. This seems to help with various
+# "spurious network error" warnings when Cargo attempts to fetch from crates.io
+# when building this image on Docker Hub and GitHub Actions build machines.
+#
+# `cargo install` is used instead of `cargo build` because it places just the
+# binaries we need into a predictable output directory. We can't control this
+# with arguments to cargo build as `--out-dir` is unstable and contentious and
+# `--target-dir` still requires us to know which profile and target the
+# binaries were built for. By using `cargo install` we can also avoid needing
+# to hard-code the set of binary names to copy so that if we add or remove
+# built binaries in future this will "just work". Note that `--root /tmp/out`
+# actually causes the binaries to be placed in `/tmp/out/bin/`. `cargo install`
+# will create the output directory for us.
+RUN CARGO_HTTP_MULTIPLEXING=false cargo install \
+  --locked \
+  --path . \
+  --root /tmp/out/ \
+  ${CARGO_ARGS}
 
+
+# -----------------------------------------------------------------------------
+# Docker stage: copy
+# -----------------------------------------------------------------------------
+# Only used when MODE=copy.
 #
-# -- stage 2: create an image containing just the binaries, configs &
-#             scripts needed to run Krill, and not the things needed to build
-#             it.
+# Copy binaries from the host directory 'dockerbin/$TARGETPLATFORM' directory
+# into this build stage to the same predictable location that binaries would be
+# in if MODE were 'build'.
 #
-FROM ${BASE_IMG}
-COPY --from=build /tmp/krill_sync/target/x86_64-alpine-linux-musl/release/krill-sync /usr/local/bin/
+# Requires that `docker build` be invoked with variable `DOCKER_BUILDKIT=1` set
+# in the environment. This is necessary so that Docker will skip the unused
+# 'build' stage and so that the magic $TARGETPLATFORM ARG will be set for us.
+FROM ${BASE_IMG} AS copy
+ARG TARGETPLATFORM
+ONBUILD COPY dockerbin/$TARGETPLATFORM /tmp/out/bin/
+
+
+# -----------------------------------------------------------------------------
+# Docker stage: source
+# -----------------------------------------------------------------------------
+# This is a "magic" build stage that "labels" a chosen prior build stage as the
+# one that the build stage after this one should copy application binaries
+# from. It also causes the ONBUILD COPY command from the 'copy' stage to be run
+# if needed. Finally, we ensure binaries have the executable flag set because
+# when copied in from outside they may not have the flag set, especially if
+# they were uploaded as a GH actions artifact then downloaded again which
+# causes file permissions to be lost.
+# See: https://github.com/actions/upload-artifact#permission-loss
+FROM ${MODE} AS source
+RUN chmod a+x /tmp/out/bin/*
+
+
+# -----------------------------------------------------------------------------
+# Docker stage: final
+# -----------------------------------------------------------------------------
+# Create an image containing just the binaries, configs & scripts needed to run
+# our app, and not the things needed to build it.
+#
+# The previous build stage from which binaries are copied is controlled by the
+# MODE ARG (see above).
+FROM ${BASE_IMG} AS final
+
+# Copy binaries from the 'source' build stage into the image we are building
+COPY --from=source /tmp/out/bin/* /usr/local/bin/
 
 # Build variables for uid and guid of user to run container
 ARG RUN_USER=krill_sync
 ARG RUN_USER_UID=1012
 ARG RUN_USER_GID=1012
 
-RUN apk add bash libgcc openssl tzdata util-linux
+# Install required runtime dependencies
+RUN apk add --no-cache bash libgcc openssl tini tzdata util-linux
 
+# Create the user and group to run the application as
 RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
     adduser -D -u ${RUN_USER_UID} -G ${RUN_USER} ${RUN_USER}
 
 # Create the data directories and create a volume for them
 VOLUME /data
-RUN mkdir -p /data/state /datarsync /data/rrdp && \
+RUN mkdir -p /data/state /data/rsync /data/rrdp && \
     chown -R ${RUN_USER_UID}:${RUN_USER_GID} /data
 
 # Install a Docker entrypoint script that will be executed when the container
 # runs
 COPY docker/entrypoint.sh /opt/
-RUN chown ${RUN_USER_UID}:${RUN_USER_GID} /opt/entrypoint.sh
+RUN chown ${RUN_USER}: /opt/entrypoint.sh
 
-# Set default, non-existend rrdp url
+# Switch to our applications user
+USER ${RUN_USER}
+
+# Set default, non-existent RRDP URL
 ENV RRDP_URL="https://localhost/notification.xml"
 
-WORKDIR /tmp
-
-# Use Tini to ensure that krill-sync responds to CTRL-C when run in the
+# Use Tini to ensure that our application responds to CTRL-C when run in the
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).
-RUN apk add --no-cache tini
-
-# Run as ${RUN_USER} - not root
-USER ${RUN_USER}
-# Tini is now available at /sbin/tini
-CMD ["/sbin/tini", "--", "/opt/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/opt/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,9 +166,6 @@ RUN chown ${RUN_USER}: /opt/entrypoint.sh
 # Switch to our applications user
 USER ${RUN_USER}
 
-# Set default, non-existent RRDP URL
-ENV RRDP_URL="https://localhost/notification.xml"
-
 # Use Tini to ensure that our application responds to CTRL-C when run in the
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # run krill-sync with variable interpolation
 set -e
-FORMAT="${FORMAT:Both}"
 DATA="${DATA:-/data}"
 RRDP_DIR="${RRDP_DIR:-$DATA/rrdp}"
 RSYNC_DIR="${RSYNC_DIR:-$DATA/rsync}"
@@ -12,6 +11,4 @@ exec /usr/local/bin/krill-sync \
     --rrdp-dir ${RRDP_DIR} \
     --rsync-dir ${RSYNC_DIR} \
     --state-dir ${STATE_DIR} \
-    --format ${FORMAT} \
-    --pid-file ${DATA}/krill-sync.pid \
     ${RRDP_URL}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,4 +11,4 @@ exec /usr/local/bin/krill-sync \
     --rrdp-dir ${RRDP_DIR} \
     --rsync-dir ${RSYNC_DIR} \
     --state-dir ${STATE_DIR} \
-    ${RRDP_URL}
+    "$@"

--- a/pkg/rules/docker-images-to-build.yml
+++ b/pkg/rules/docker-images-to-build.yml
@@ -1,0 +1,6 @@
+# See: https://github.com/NLnetLabs/ploutos/blob/main/docs/docker_packaging.md#docker-build-rules
+---
+include:
+  - platform: "linux/amd64"
+    shortname: "amd64"
+    mode: "build"

--- a/pkg/rules/docker-images-to-build.yml
+++ b/pkg/rules/docker-images-to-build.yml
@@ -1,6 +1,21 @@
 # See: https://github.com/NLnetLabs/ploutos/blob/main/docs/docker_packaging.md#docker-build-rules
 ---
 include:
-  - platform: "linux/amd64"
-    shortname: "amd64"
-    mode: "build"
+  - platform:    'linux/amd64'
+    shortname:   'amd64'
+    mode:        'build'
+
+  - platform:    'linux/arm/v6'
+    shortname:   'armv6'
+    crosstarget: 'arm-unknown-linux-musleabihf'
+    mode:        'copy'
+
+  - platform:    'linux/arm/v7'
+    shortname:   'armv7'
+    crosstarget: 'armv7-unknown-linux-musleabihf'
+    mode:        'copy'
+
+  - platform:    'linux/arm64'
+    shortname:   'arm64'
+    crosstarget: 'aarch64-unknown-linux-musl'
+    mode:        'copy'


### PR DESCRIPTION
This PR configures Ploutos to build an linux/amd64 and ARM cross-compiled Docker images and sanity checks the amd64 image by invoking the `krill-sync --version` command. It also adds support for using vendored TLS support to support compilation for cross-compiled targets in the same way we do for Krill.

The primary reason for adding this was to exercise/validate the `Dockerfile` as it was recently discovered not to be working with the version of Rust contained in the outdated Alpine base image it was using but this went unnoticed due to the build process not building the Docker image. This PR was then substantially updated to cover the https://github.com/NLnetLabs/krill-sync/pull/79 use case as well.

This PR will publish the produced image to Docker Hub per the rules [documented for Ploutos](https://github.com/NLnetLabs/ploutos/blob/main/docs/docker_packaging.md#outputs):

> If the required secrets are defined (see above), and the git ref is either the main branch or a v* tag, then the Docker image will be published to Docker Hub with the generated image name (see above).

An example successful run of the updated GitHub Action can be seen here: https://github.com/NLnetLabs/krill-sync/actions/runs/5936867130